### PR TITLE
Adding nowrap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The editor accepts all the props accepted by `textarea`. In addition, you can pa
 - `tabSize` (`number`): The number of characters to insert when pressing tab key. For example, for 4 space indentation, `tabSize` will be `4` and `insertSpaces` will be `true`. Default: `2`.
 - `insertSpaces` (`boolean`): Whether to use spaces for indentation. Default: `true`. If you set it to `false`, you might also want to set `tabSize` to `1`.
 - `ignoreTabKey` (`boolean`): Whether the editor should ignore tab key presses so that keyboard users can tab past the editor. Users can toggle this behaviour using `Ctrl+Shift+M` (Mac) / `Ctrl+M` manually when this is `false`. Default: `false`.
+- `noWrap` (`boolean`): Whether the lines should break as necessary to fill line boxes. Default: `false`.
 - `padding` (`number`): Optional padding for code. Default: `0`.
 - `textareaId` (`string`): An ID for the underlying `textarea`, can be useful for setting a `label`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare module '@outsystems/react-simple-code-editor' {
       tabSize?: number;
       insertSpaces?: boolean;
       ignoreTabKey?: boolean;
+      noWrap?: boolean;
       padding?: number | string;
       style?: React.CSSProperties;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outsystems/react-simple-code-editor",
-  "version": "0.9.14",
+  "version": "0.9.5-os4",
   "description": "A fork of react-simple-code-editor to generate AMD module",
   "keywords": [
     "code",

--- a/src/index.js
+++ b/src/index.js
@@ -516,6 +516,7 @@ export default class Editor extends React.Component<Props, State> {
       placeholder,
       readOnly,
       required,
+      noWrap,
       onClick,
       onFocus,
       onBlur,
@@ -535,6 +536,7 @@ export default class Editor extends React.Component<Props, State> {
       paddingRight: padding,
       paddingBottom: padding,
       paddingLeft: padding,
+      whiteSpace: noWrap ? 'pre' : 'pre-wrap',
     };
 
     const highlighted = highlight(value);
@@ -628,8 +630,7 @@ const styles = {
     textIndent: 'inherit',
     textRendering: 'inherit',
     textTransform: 'inherit',
-    whiteSpace: 'pre-wrap',
     wordBreak: 'keep-all',
-    overflowWrap: 'break-word',
+    overflowWrap: 'break-word'
   },
 };


### PR DESCRIPTION
This is just an apply of this PR https://github.com/satya164/react-simple-code-editor/pull/36 that we need to address some of the issues mentioned at https://outsystemsrd.atlassian.net/browse/RMAC-4587

I changed also the version format to use the format original_version-os[\d] where the last digit represent the nth version that we release in this branch